### PR TITLE
Add auth token support

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,10 @@ which produces:
 
 ```json
 {
-  "baseUrl": "YOUR_BASE_URL",
-  "user": "YOUR_USERNAME",
-  "pass": "YOUR_PASSWORD",
+  "baseUrl": "<your base URL>",
+  "user": "<your username>",
+  "pass": "<your password>",
+  "authToken": "<your auth token (can be set instead of username/password)>",
   "cachePath": "build",
   "prefix": "This document is automatically generated. Please don't edit it directly!",
   "pages": [
@@ -69,14 +70,22 @@ which produces:
 In most scenarios it is not recommended to store your credentials in the configuration file, because you will probably add it to your VCS. Instead it is recommended to provide the following environment variables in your build pipeline (GitLab CI, GitHub Actions, Jenkins, ...):
 
 ```ini
-CONFLUENCE_USERNAME=YOUR_USERNAME
-CONFLUENCE_PASSWORD=YOUR_PASSWORD
+CONFLUENCE_USERNAME="<your username>"
+CONFLUENCE_PASSWORD="<your password>"
+```
+
+or
+
+```ini
+CONFLUENCE_AUTH_TOKEN="<your auth token>"
 ```
 
 or add it in front of the command when executing locally (add a space in front of the command when using bash in order to not write the credentials to the bash history):
 
 ```bash
- CONFLUENCE_USER=YOUR_USERNAME CONFLUENCE_PASSWORD=YOUR_PASSWORD cosmere
+ CONFLUENCE_USER="<your username>" CONFLUENCE_PASSWORD="<your password>" cosmere
+# or
+ CONFLUENCE_AUTH_TOKEN="<your auth token>" cosmere
 ```
 
 ### Run

--- a/bin/cosmere
+++ b/bin/cosmere
@@ -12,9 +12,9 @@ Options:
 `);
 
 if (options['generate-config']) {
-  require('../dist/src/GenerateCommand').default(options['--config']);
+  require('../dist/src/cli/GenerateCommand').default(options['--config']);
 } else {
-  require('../dist/src/MainCommand').default(options['--config'], options['--force'])
+  require('../dist/src/cli/MainCommand').default(options['--config'], options['--force'])
     .then()
     .catch(e  => {
         require('signale').fatal(e);

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
   "homepage": "https://mihaeu.github.io/cosmere/",
   "devDependencies": {
     "@types/inquirer": "^6.5.0",
+    "@types/jest": "^27.4.0",
     "@types/marked": "^0.7.1",
     "@types/node": "^12.12.7",
     "@types/signale": "^1.2.1",

--- a/src/ConfigLoader.ts
+++ b/src/ConfigLoader.ts
@@ -1,60 +1,79 @@
 import * as path from "path";
 import * as fs from "fs";
-import { Config } from "./types/Config";
+import { Config, ConfigKey, isBasicAuth, isTokenAuth } from "./types/Config";
 import * as inquirer from "inquirer";
 import signale from "signale";
 
-export class ConfigLoader {
-    static async load(configPath: string | null): Promise<Config> {
-        return await ConfigLoader.promptUserAndPassIfNotSet(
-            ConfigLoader.overwriteAuthFromConfigWithEnvIfPresent(ConfigLoader.readConfigFromFile(configPath)),
-        );
+
+function overwriteConfigKeyWithEnvVarIfPresent<T>(config: Partial<Config>, configKey: ConfigKey, envKey: string): Partial<Config> {
+    if (configKey === "pages") {
+        throw Error("Cannot override pages using environment variable");
     }
 
-    private static readConfigFromFile(configPath: string | null): Config {
+    if (process.env[envKey] !== undefined) {
+        return { ...config, [configKey]: process.env[envKey] };
+    } else {
+        return config;
+    }
+}
+
+
+export class ConfigLoader {
+    static async load(configPath: string | null): Promise<Partial<Config>> {
+        let config = ConfigLoader.readConfigFromFile(configPath);
+        config = ConfigLoader.overwriteAuthFromConfigWithEnvIfPresent(config),
+        config = await ConfigLoader.promptUserAndPassIfNoCredentialsSet(config);
+        return config;
+    }
+
+    private static readConfigFromFile(configPath: string | null): Partial<Config> {
         configPath = path.resolve(configPath || path.join("cosmere.json"));
         if (!fs.existsSync(configPath!)) {
             signale.fatal(`File "${configPath}" not found!`);
             process.exit(1);
         }
 
-        let config = JSON.parse(fs.readFileSync(configPath!, "utf8")) as Config;
-        for (const i in config.pages) {
-            config.pages[i].file = path.isAbsolute(config.pages[i].file)
-                ? config.pages[i].file
-                : path.resolve(path.dirname(configPath) + "/" + config.pages[i].file);
+        let config: Partial<Config> = JSON.parse(fs.readFileSync(configPath!, "utf8"));
+        if (config.pages !== undefined) {
+            for (const i in config.pages) {
+                config.pages[i].file = path.isAbsolute(config.pages[i].file)
+                    ? config.pages[i].file
+                    : path.resolve(path.dirname(configPath) + "/" + config.pages[i].file);
+            }
         }
         config.configPath = configPath;
         return config;
     }
 
-    private static overwriteAuthFromConfigWithEnvIfPresent(config: Config): Config {
-        config.user = process.env.CONFLUENCE_USERNAME || config.user;
-        config.pass = process.env.CONFLUENCE_PASSWORD || config.pass;
+    private static overwriteAuthFromConfigWithEnvIfPresent(config: Partial<Config>): Partial<Config> {
+        config = overwriteConfigKeyWithEnvVarIfPresent(config, "user", "CONFLUENCE_USERNAME");
+        config = overwriteConfigKeyWithEnvVarIfPresent(config, "pass", "CONFLUENCE_PASSWORD");
+        config = overwriteConfigKeyWithEnvVarIfPresent(config, "authToken", "CONFLUENCE_AUTH_TOKEN");
         return config;
     }
 
-    private static async promptUserAndPassIfNotSet(config: Config): Promise<Config> {
-        const prompts = [];
-        if (!config.user) {
-            prompts.push({
+    private static async promptUserAndPassIfNoCredentialsSet(config: Partial<Config>): Promise<Partial<Config>> {
+        if (isTokenAuth(config)) {
+            return config;
+        }
+
+        if (!("user" in config)) {
+            const answers = await inquirer.prompt([{
                 type: "input",
                 name: "user",
                 message: "Your Confluence username:",
-            });
+            }]);
+            (config as any).user = answers.user;
         }
 
-        if (!config.pass) {
-            prompts.push({
+        if (!("pass" in config)) {
+            const answers = await inquirer.prompt([{
                 type: "password",
                 name: "pass",
                 message: "Your Confluence password:",
-            });
+            }]);
+            (config as any).pass = answers.pass;
         }
-
-        const answers = await inquirer.prompt(prompts);
-        config.user = config.user || (answers.user as string);
-        config.pass = config.pass || (answers.pass as string);
 
         return config;
     }

--- a/src/api/ConfluenceAPI.ts
+++ b/src/api/ConfluenceAPI.ts
@@ -1,29 +1,22 @@
-import { AuthHeaders } from "../types/AuthHeaders";
-import axios from "axios";
+import { AuthConfig, isBasicAuth, isTokenAuth } from "../types/Config";
+import axios, { AxiosRequestConfig } from "axios";
 import * as fs from "fs";
 import signale from "signale";
 
-export class ConfluenceAPI {
-    private readonly authHeaders: AuthHeaders;
-    private readonly baseUrl: string;
 
-    constructor(baseUrl: string, username: string, password: string) {
-        this.baseUrl = baseUrl;
-        this.authHeaders = {
-            auth: {
-                username: username,
-                password: password,
-            },
-        };
-    }
+export class ConfluenceAPI {
+    constructor(
+        private readonly baseUrl: string,
+        private readonly authConfig: AuthConfig
+    ) {}
 
     async updateConfluencePage(pageId: string, newPage: any) {
-        const config = {
+        const config = this.appendAuthHeaders({
             headers: {
                 "Content-Type": "application/json",
             },
-            ...this.authHeaders,
-        };
+        });
+
         try {
             await axios.put(`${this.baseUrl}/content/${pageId}`, newPage, config);
         } catch (e) {
@@ -33,11 +26,12 @@ export class ConfluenceAPI {
     }
 
     async deleteAttachments(pageId: string) {
-        const attachments = await axios.get(`${this.baseUrl}/content/${pageId}/child/attachment`, this.authHeaders);
+        const config = this.appendAuthHeaders({});
+        const attachments = await axios.get(`${this.baseUrl}/content/${pageId}/child/attachment`, config);
         for (const attachment of attachments.data.results) {
             try {
                 signale.await(`Deleting attachment "${attachment.title}" ...`);
-                await axios.delete(`${this.baseUrl}/content/${attachment.id}`, this.authHeaders);
+                await axios.delete(`${this.baseUrl}/content/${attachment.id}`, config);
             } catch (e) {
                 signale.error(`Deleting attachment "${attachment.title}" failed ...`);
             }
@@ -46,7 +40,7 @@ export class ConfluenceAPI {
 
     async uploadAttachment(filename: string, pageId: string) {
         try {
-            await require("axios-file")({
+            const config = this.appendAuthHeaders({
                 url: `${this.baseUrl}/content/${pageId}/child/attachment`,
                 method: "post",
                 headers: {
@@ -55,14 +49,40 @@ export class ConfluenceAPI {
                 data: {
                     file: fs.createReadStream(filename),
                 },
-                ...this.authHeaders,
             });
+
+            await require("axios-file")(config);
         } catch (e) {
             signale.error(`Uploading attachment "${filename}" failed ...`);
         }
     }
 
     async currentPage(pageId: string) {
-        return axios.get(`${this.baseUrl}/content/${pageId}?expand=body.storage,version`, this.authHeaders);
+        const config = this.appendAuthHeaders({});
+        return axios.get(`${this.baseUrl}/content/${pageId}?expand=body.storage,version`, config);
+    }
+
+    private appendAuthHeaders(config: AxiosRequestConfig): AxiosRequestConfig {
+        if (isBasicAuth(this.authConfig)) {
+            return {
+                ...config,
+                auth: {
+                    username: this.authConfig.user,
+                    password: this.authConfig.pass,
+                },
+            };
+        }
+        else if (isTokenAuth(this.authConfig)) {
+            return {
+                ...config,
+                headers: {
+                    ...(config.headers ?? {}),
+                    "Authorization": `Bearer ${this.authConfig.authToken}`,
+                }
+            }
+        }
+        else {
+            throw Error("No credentials found in config");
+        }
     }
 }

--- a/src/cli/GenerateCommand.ts
+++ b/src/cli/GenerateCommand.ts
@@ -5,9 +5,10 @@ export default function(configPath: string | null) {
     fs.writeFileSync(
         configPath || path.join("cosmere.json")!,
         `{
-  "baseUrl": "YOUR_BASE_URL",
-  "user": "YOUR_USERNAME",
-  "pass": "YOUR_PASSWORD",
+  "baseUrl": "<your base URL>",
+  "user": "<your username>",
+  "pass": "<your password>",
+  "authToken": "<your auth token (can be set instead of username/password)>",
   "cachePath": "build",
   "prefix": "This document is automatically generated. Please don't edit it directly!",
   "pages": [

--- a/src/cli/MainCommand.ts
+++ b/src/cli/MainCommand.ts
@@ -4,8 +4,8 @@ import { ConfluenceAPI } from "../api/ConfluenceAPI";
 import { updatePage } from "../UpdatePage";
 
 export default async function(configPath: string | null, force: boolean = false) {
-    const config: Config = await ConfigLoader.load(configPath);
-    const confluenceAPI = new ConfluenceAPI(config.baseUrl, config.user!, config.pass!);
+    const config: Config = await ConfigLoader.load(configPath) as Config;
+    const confluenceAPI = new ConfluenceAPI(config.baseUrl, config);
 
     for (const pageData of config.pages) {
         await updatePage(confluenceAPI, pageData, config, force);

--- a/src/types/AuthHeaders.ts
+++ b/src/types/AuthHeaders.ts
@@ -1,6 +1,0 @@
-export type AuthHeaders = {
-    auth: {
-        username: string;
-        password: string;
-    };
-};

--- a/src/types/Config.ts
+++ b/src/types/Config.ts
@@ -1,11 +1,30 @@
 import { Page } from "./Page";
 
-export type Config = {
+export type BasicAuthConfig = {
+    user: string;
+    pass: string;
+};
+
+export type TokenAuthConfig = {
+    authToken: string;
+};
+
+export type AuthConfig = BasicAuthConfig | TokenAuthConfig;
+
+export type Config = AuthConfig & {
     baseUrl: string;
     cachePath: string;
-    user?: string;
-    pass?: string;
-    prefix: string;
+    prefix?: string;
     pages: Page[];
     configPath: string | null;
 };
+
+export type ConfigKey = keyof BasicAuthConfig | keyof TokenAuthConfig | keyof Config;
+
+export function isBasicAuth(authConfig: Object): authConfig is BasicAuthConfig {
+    return authConfig.hasOwnProperty("user");
+}
+
+export function isTokenAuth(authConfig: Object): authConfig is TokenAuthConfig {
+    return authConfig.hasOwnProperty("authToken");
+}

--- a/tests/UpdatePage.test.ts
+++ b/tests/UpdatePage.test.ts
@@ -10,12 +10,14 @@ describe("UpdatePage", () => {
       file: "/dev/null"
     };
     const config: Config = {
+      user: "",
+      pass: "",
       baseUrl: "string",
       cachePath: "string",
       prefix: "string",
       pages: [],
       configPath: null,
     };
-    expect(updatePage(new ConfluenceAPI("", "", ""), pageData, config, false)).toBeFalsy();
+    expect(updatePage(new ConfluenceAPI("", config), pageData, config, false)).toBeFalsy();
   });
 });

--- a/tests/api/ConfluenceAPI.test.ts
+++ b/tests/api/ConfluenceAPI.test.ts
@@ -6,10 +6,10 @@ jest.mock('axios');
 const axiosMock = mocked(axios, true);
 
 describe("ConfluenceAPI", () => {
-  it("fetches current version of confluence page", async () => {
+  it("fetches current version of confluence page using basic auth", async () => {
     axiosMock.get.mockResolvedValue({ data: "Test"});
 
-    const confluenceAPI = new ConfluenceAPI("", "", "");
+    const confluenceAPI = new ConfluenceAPI("", { user: "", pass: "" });
     await confluenceAPI.currentPage("2");
     expect(axiosMock.get).toHaveBeenCalledWith(
       "/content/2?expand=body.storage,version",
@@ -17,6 +17,22 @@ describe("ConfluenceAPI", () => {
         auth: {
           password: "",
           username: ""
+        }
+      }
+    );
+  });
+
+  it("fetches current version of confluence page using auth token", async () => {
+    axiosMock.get.mockResolvedValue({ data: "Test"});
+
+    const authToken = "foo";
+    const confluenceAPI = new ConfluenceAPI("", { authToken });
+    await confluenceAPI.currentPage("2");
+    expect(axiosMock.get).toHaveBeenCalledWith(
+      "/content/2?expand=body.storage,version",
+      {
+        headers: {
+          Authorization: `Bearer ${authToken}`,
         }
       }
     );

--- a/tests/cli/GenerateCommand.test.ts
+++ b/tests/cli/GenerateCommand.test.ts
@@ -7,9 +7,10 @@ describe("GenerateCommand", () => {
     const path = os.tmpdir() + '/cosmere.json';
     GenerateCommand(path);
     expect(fs.readFileSync(path, "utf8")).toBe(`{
-  "baseUrl": "YOUR_BASE_URL",
-  "user": "YOUR_USERNAME",
-  "pass": "YOUR_PASSWORD",
+  "baseUrl": "<your base URL>",
+  "user": "<your username>",
+  "pass": "<your password>",
+  "authToken": "<your auth token (can be set instead of username/password)>",
   "cachePath": "build",
   "prefix": "This document is automatically generated. Please don't edit it directly!",
   "pages": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -648,6 +648,14 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
+"@types/jest@^27.4.0":
+  version "27.4.0"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-27.4.0.tgz#037ab8b872067cae842a320841693080f9cb84ed"
+  integrity sha512-gHl8XuC1RZ8H2j5sHv/JqsaxXkDDM9iDOgu0Wp8sjs4u/snb2PVehyWXJPr+ORA0RPpgw231mnutWI1+0hgjIQ==
+  dependencies:
+    jest-diff "^27.0.0"
+    pretty-format "^27.0.0"
+
 "@types/keyv@*", "@types/keyv@^3.1.1":
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/@types/keyv/-/keyv-3.1.3.tgz#1c9aae32872ec1f20dcdaee89a9f3ba88f465e41"
@@ -828,6 +836,11 @@ ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
   dependencies:
     color-convert "^2.0.1"
+
+ansi-styles@^5.0.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-5.2.0.tgz#07449690ad45777d1924ac2abb2fc8895dba836b"
+  integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
 
 any-observable@^0.3.0:
   version "0.3.0"
@@ -1587,6 +1600,11 @@ diff-sequences@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-26.6.2.tgz#48ba99157de1923412eed41db6b6d4aa9ca7c0b1"
   integrity sha512-Mv/TDa3nZ9sbc5soK+OoA74BsS3mL37yixCvUAQkiuA4Wz6YtwP/K47n2rv2ovzHZvoiQeA5FTQOschKkEwB0Q==
+
+diff-sequences@^27.4.0:
+  version "27.4.0"
+  resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-27.4.0.tgz#d783920ad8d06ec718a060d00196dfef25b132a5"
+  integrity sha512-YqiQzkrsmHMH5uuh8OdQFU9/ZpADnwzml8z0O5HvRNda+5UZsaX/xN+AAxfR2hWq1Y7HZnAzO9J5lJXOuDz2Ww==
 
 dir-glob@^3.0.1:
   version "3.0.1"
@@ -2788,6 +2806,16 @@ jest-diff@^26.6.2:
     jest-get-type "^26.3.0"
     pretty-format "^26.6.2"
 
+jest-diff@^27.0.0:
+  version "27.4.6"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-27.4.6.tgz#93815774d2012a2cbb6cf23f84d48c7a2618f98d"
+  integrity sha512-zjaB0sh0Lb13VyPsd92V7HkqF6yKRH9vm33rwBt7rPYrpQvS1nCvlIy2pICbKta+ZjWngYLNn4cCK4nyZkjS/w==
+  dependencies:
+    chalk "^4.0.0"
+    diff-sequences "^27.4.0"
+    jest-get-type "^27.4.0"
+    pretty-format "^27.4.6"
+
 jest-docblock@^26.0.0:
   version "26.0.0"
   resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-26.0.0.tgz#3e2fa20899fc928cb13bd0ff68bd3711a36889b5"
@@ -2835,6 +2863,11 @@ jest-get-type@^26.3.0:
   version "26.3.0"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-26.3.0.tgz#e97dc3c3f53c2b406ca7afaed4493b1d099199e0"
   integrity sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==
+
+jest-get-type@^27.4.0:
+  version "27.4.0"
+  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-27.4.0.tgz#7503d2663fffa431638337b3998d39c5e928e9b5"
+  integrity sha512-tk9o+ld5TWq41DkK14L4wox4s2D9MtTpKaAVzXfr5CUKm5ZK2ExcaFE0qls2W71zE/6R2TxxrK9w2r6svAFDBQ==
 
 jest-haste-map@^26.6.2:
   version "26.6.2"
@@ -4143,6 +4176,15 @@ pretty-format@^26.6.2:
     "@jest/types" "^26.6.2"
     ansi-regex "^5.0.0"
     ansi-styles "^4.0.0"
+    react-is "^17.0.1"
+
+pretty-format@^27.0.0, pretty-format@^27.4.6:
+  version "27.4.6"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-27.4.6.tgz#1b784d2f53c68db31797b2348fa39b49e31846b7"
+  integrity sha512-NblstegA1y/RJW2VyML+3LlpFjzx62cUrtBIKIWDXEDkjNeleA7Od7nrzcs/VLQvAeV4CgSYhrN39DRN88Qi/g==
+  dependencies:
+    ansi-regex "^5.0.1"
+    ansi-styles "^5.0.0"
     react-is "^17.0.1"
 
 prompts@^2.0.1:


### PR DESCRIPTION
Implements #26.

The necessary modifications to get the types right were a bit more involved than I had expected: Once I had modified `Config` to account for the fact that the user should provide *either* a username/password *or* an auth token, TSC started complaining about all kinds of things. I didn't want to give up on type safety, though, so I pulled through. :)

Also, I made two minor modifications to `package.json` and `bin/cosmere` as I couldn't get it running the way it was.

I'd be open for suggestions and improvements. :)
