### PR TITLE
basic auth for rest api requires username

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ CONFLUENCE_PASSWORD=YOUR_PASSWORD
 or
 
 ```ini
+CONFLUENCE_USERNAME=YOUR_USERNAME
 CONFLUENCE_PERSONAL_ACCESS_TOKEN="<your auth token>"
 ```
 
@@ -79,7 +80,7 @@ or add it in front of the command when executing locally (add a space in front o
 ```bash
  CONFLUENCE_USER=YOUR_USERNAME CONFLUENCE_PASSWORD=YOUR_PASSWORD cosmere
  # or
- CONFLUENCE_PERSONAL_ACCESS_TOKEN="<your personal access token>" cosmere
+ CONFLUENCE_USERNAME=YOUR_USERNAME CONFLUENCE_PERSONAL_ACCESS_TOKEN="<your personal access token>" cosmere
 ```
 
 ### Run

--- a/src/FileConfigLoader.ts
+++ b/src/FileConfigLoader.ts
@@ -4,7 +4,6 @@ import { Config } from "./types/Config";
 import * as inquirer from "inquirer";
 import signale from "signale";
 import { FileConfig } from "./types/FileConfig";
-import { Buffer } from "buffer";
 
 type AuthOptions = {
     user?: string;


### PR DESCRIPTION
The v1 api requires the username along with token authorization encoded in Basic Authorization.

https://developer.atlassian.com/cloud/confluence/basic-auth-for-rest-apis/